### PR TITLE
Fixed configure on none configuarable packages

### DIFF
--- a/src/Skeletor/Console/CreateProjectCommand.php
+++ b/src/Skeletor/Console/CreateProjectCommand.php
@@ -119,7 +119,10 @@ class CreateProjectCommand extends SkeletorCommand
 
         foreach($activePackages as $key => $package) {
             $this->packageManager->install($package);
-            $this->packageManager->configure($package, $activeFramework);
+
+            if($package instanceof ConfigurablePackageInterface) {
+                $this->packageManager->configure($package, $activeFramework);
+            }
         }
     }
 }


### PR DESCRIPTION
When a package isn't configurable, don't configure it in the build.