### PR TITLE
Feature/generate providers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,13 +7,19 @@ Adding new: framework, package or default package, is really easy. All of those 
 Add the name of the new Framework to the `skeletor.yml`
 For example we add `Test54Framework`, now make a blueprint for the framework `src/Skeletor/Frameworks/Test54Framework.php`.
 This blueprint will define, more detail about the framework and give you the freedom to configure it.
-Take a look at the `Framework.php` here are all available methods, also take a look at the [Flysystem docs](https://flysystem.thephpleague.com/api/). 
+Take a look at the `FrameworkInterface.php` here are all available methods, also take a look at the [Flysystem docs](https://flysystem.thephpleague.com/api/). 
 
 ### Packages
+##### With Skeletor
+You can also add a package with `skeletor package:add package/name`, it will search on Packagist and give you some options.
+##### Doing it maunaly
 Add the name of the new package to the `skeletor.yml`
 For example we add `TestPackage`, now make a blueprint for the package `src/Skeletor/Packages/TestPackage.php`.
 This blueprint will define, more detail about the package and give you the freedom to configure it.
-Take a look at the `Package.php` here are all available methods, also take a look at the [Flysystem docs](https://flysystem.thephpleague.com/api/). 
+Take a look at the `PackageInterface.php` here are all available methods, also take a look at the [Flysystem docs](https://flysystem.thephpleague.com/api/). 
+
+Once you installed the basic package, you can configure it further.
+Take a look at `BarryvdhLaravelDebugbarPackage.php` for an good example.
 
 ### Default packages
 Same process as the packages, only add this package name under defaultPackages in the `skeletor.yml`.

--- a/src/Skeletor/App/Config/SkeletorConfigurator.php
+++ b/src/Skeletor/App/Config/SkeletorConfigurator.php
@@ -20,6 +20,14 @@ class SkeletorConfigurator
     /**
      * @return array
      */
+    public function getManagers()
+    {
+        return $this->options['managers'];
+    }
+
+    /**
+     * @return array
+     */
     public function getFrameworks()
     {
         return $this->options['frameworks'];

--- a/src/Skeletor/App/Config/skeletor.yml
+++ b/src/Skeletor/App/Config/skeletor.yml
@@ -9,3 +9,8 @@ packages:
     - KielabokkieJsonapiBehatExtensionPackage
 defaultPackages:
     - PixelfusionGitHooksPackage
+managers:
+    - ComposerManager
+    - FrameworkManager
+    - PackageManager
+    - ProviderManager

--- a/src/Skeletor/App/Config/skeletor.yml
+++ b/src/Skeletor/App/Config/skeletor.yml
@@ -1,5 +1,5 @@
 config:
-    name: Skeletor CLI
+    name: 'Skeletor CLI'
     version: 1.0.0
 frameworks:
     - Laravel54Framework
@@ -7,6 +7,7 @@ frameworks:
 packages:
     - BehatBehatPackage
     - KielabokkieJsonapiBehatExtensionPackage
+    - BarryvdhLaravelDebugbarPackage
 defaultPackages:
     - PixelfusionGitHooksPackage
 managers:

--- a/src/Skeletor/Console/CreateProjectCommand.php
+++ b/src/Skeletor/Console/CreateProjectCommand.php
@@ -122,6 +122,7 @@ class CreateProjectCommand extends SkeletorCommand
 
             if ($package instanceof ConfigurablePackageInterface) {
                 $this->packageManager->configure($package, $activeFramework);
+                $this->providerManager->configure($package, $activeFramework);
             }
         }
     }

--- a/src/Skeletor/Console/CreateProjectCommand.php
+++ b/src/Skeletor/Console/CreateProjectCommand.php
@@ -4,6 +4,7 @@ namespace Skeletor\Console;
 use Skeletor\Exceptions\FailedFilesystem;
 use Skeletor\Frameworks\Framework;
 use Skeletor\Packages\ConfigurablePackageInterface;
+use Skeletor\Packages\ProviderInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Skeletor/Console/SkeletorCommand.php
+++ b/src/Skeletor/Console/SkeletorCommand.php
@@ -9,23 +9,26 @@ abstract class SkeletorCommand extends Command
     protected $packagistApi;
     protected $configurator;
     protected $packageManager;
+    protected $providerManager;
     protected $frameworkManager;
     protected $skeletorFilesystem;
 
     protected function setupCommand($dryRun = false)
     {
+        $app = $this->getApplication();
         $this->getApplication()->registerServices($dryRun);
 
-        $this->cli = $this->getApplication()->getCli();
-        $this->packagistApi = $this->getApplication()->getPackagistApi();
-        $this->configurator = $this->getApplication()->getConfigurator();
-        $this->skeletorFilesystem = $this->getApplication()->getSkeletorFilesystem();
+        $this->cli = $app->getCli();
+        $this->packagistApi = $app->getPackagistApi();
+        $this->configurator = $app->getConfigurator();
+        $this->skeletorFilesystem = $app->getSkeletorFilesystem();
 
-        $this->frameworkManager = $this->getApplication()->getFrameworkManager();
-        $this->packageManager = $this->getApplication()->getPackageManager();
+        $this->frameworkManager = $app->getFrameworkManager();
+        $this->packageManager = $app->getPackageManager();
+        $this->providerManager = $app->getProviderManager();
 
-        $this->frameworkManager->setFrameworks($this->getApplication()->getFrameworks());
-        $this->packageManager->setPackages($this->getApplication()->getPackages());
-        $this->packageManager->setDefaultPackages($this->getApplication()->getDefaultPackages());
+        $this->frameworkManager->setFrameworks($app->getFrameworks());
+        $this->packageManager->setPackages($app->getPackages());
+        $this->packageManager->setDefaultPackages($app->getDefaultPackages());
     }
 }

--- a/src/Skeletor/Frameworks/Framework.php
+++ b/src/Skeletor/Frameworks/Framework.php
@@ -87,7 +87,7 @@ abstract class Framework implements FrameworkInterface
      */
     public function getPath(string $path)
     {
-        if(array_key_exists($path, $this->paths) === false){
+        if (!array_key_exists($path, $this->paths)) {
             throw new FailedFilesystem("Couldn't find {$path}");
         }
 

--- a/src/Skeletor/Frameworks/Framework.php
+++ b/src/Skeletor/Frameworks/Framework.php
@@ -3,6 +3,7 @@ namespace Skeletor\Frameworks;
 
 use League\Flysystem\Filesystem;
 use League\Flysystem\MountManager;
+use Skeletor\Exceptions\FailedFilesystem;
 use Skeletor\Manager\ComposerManager;
 
 abstract class Framework implements FrameworkInterface
@@ -86,11 +87,11 @@ abstract class Framework implements FrameworkInterface
      */
     public function getPath(string $path)
     {
-        if(array_key_exists($path, $this->paths)){
-            return $this->paths[$path];
+        if(array_key_exists($path, $this->paths) === false){
+            throw new FailedFilesystem("Couldn't find {$path}");
         }
 
-        return '';
+        return $this->paths[$path];
     }
 
     /**

--- a/src/Skeletor/Frameworks/FrameworkInterface.php
+++ b/src/Skeletor/Frameworks/FrameworkInterface.php
@@ -14,4 +14,5 @@ interface FrameworkInterface
     public function setPaths(array $paths);
     public function install();
     public function configure();
+    public function configurable();
 }

--- a/src/Skeletor/Frameworks/Laravel54Framework.php
+++ b/src/Skeletor/Frameworks/Laravel54Framework.php
@@ -7,7 +7,7 @@ class Laravel54Framework extends Framework
     {
         $this->setInstallSlug('laravel/laravel');
         $this->setName("Laravel");
-        $this->setVersion("5.4");
+        $this->setVersion("5.4.*");
         $this->setPaths([
             'tests' => 'tests',
             'appConfig' => 'config/app.php'

--- a/src/Skeletor/Frameworks/Laravel54Framework.php
+++ b/src/Skeletor/Frameworks/Laravel54Framework.php
@@ -24,4 +24,9 @@ class Laravel54Framework extends Framework
         //     'project://app/namespace/pixelfusion/bootstrap/FeatureContext.php'
         // );
     }
+
+    public function configurable()
+    {
+        return true;
+    }
 }

--- a/src/Skeletor/Frameworks/Laravel54Framework.php
+++ b/src/Skeletor/Frameworks/Laravel54Framework.php
@@ -10,6 +10,7 @@ class Laravel54Framework extends Framework
         $this->setVersion("5.4");
         $this->setPaths([
             'tests' => 'tests',
+            'appConfig' => 'config/app.php'
         ]);
     }
 

--- a/src/Skeletor/Frameworks/LaravelLumen54Framework.php
+++ b/src/Skeletor/Frameworks/LaravelLumen54Framework.php
@@ -15,4 +15,9 @@ class LaravelLumen54Framework extends Framework
         $this->projectFilesystem->put('PixelFusion.txt', '©PIXELFUSION');
         $this->projectFilesystem->createDir('setup/git-hooks');
     }
+
+    public function configurable()
+    {
+        return false;
+    }
 }

--- a/src/Skeletor/Manager/Manager.php
+++ b/src/Skeletor/Manager/Manager.php
@@ -7,18 +7,22 @@ use League\Flysystem\Filesystem;
 abstract class Manager
 {
     protected $skeletorFilesystem;
+    protected $projectFilesystem;
     protected $options;
     protected $cli;
 
     /**
      * Manager constructor.
      * @param CLImate $cli
+     * @param Filesystem $projectFilesystem
+     * @param Filesystem $skeletorFilesystem
      * @param array $options
      */
-  public function __construct(CLImate $cli, Filesystem $skeletorFilesystem, array $options)
+    public function __construct(CLImate $cli, Filesystem $skeletorFilesystem, Filesystem $projectFilesystem, array $options)
     {
         $this->cli = $cli;
         $this->options = $options;
+        $this->projectFilesystem = $projectFilesystem;
         $this->skeletorFilesystem = $skeletorFilesystem;
     }
 }

--- a/src/Skeletor/Manager/ProviderManager.php
+++ b/src/Skeletor/Manager/ProviderManager.php
@@ -7,7 +7,7 @@ use Skeletor\Packages\Package;
 
 class ProviderManager extends Manager
 {
-    const PROVIDER_METHOD = 'getWriteableProvider';
+    const PROVIDER_METHOD = 'getProviderClass';
     const FACADE_METHOD = 'getFacadeClass';
 
     /**
@@ -65,7 +65,7 @@ class ProviderManager extends Manager
     {
         [$alias, $facade] = explode('@', $package->getFacade());
 
-        return sprintf("\t\t'%s' => %s::class, ", $alias, $facade) . PHP_EOL;
+        return sprintf("\t\t'%s' => %s::class,", $alias, $facade) . PHP_EOL;
     }
 
     /**

--- a/src/Skeletor/Manager/ProviderManager.php
+++ b/src/Skeletor/Manager/ProviderManager.php
@@ -68,9 +68,9 @@ class ProviderManager extends Manager
             return;
         }
 
-        [$alias, $facade] = explode('@', $package->getFacade());
+        $provider = explode('@', $package->getFacade());
 
-        return sprintf("\t\t'%s' => %s::class,", $alias, $facade) . PHP_EOL;
+        return sprintf("\t\t'%s' => %s::class,", $provider[0], $provider[1]) . PHP_EOL;
     }
 
     /**

--- a/src/Skeletor/Manager/ProviderManager.php
+++ b/src/Skeletor/Manager/ProviderManager.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Skeletor\Manager;
+
+use Skeletor\Frameworks\Framework;
+use Skeletor\Packages\Package;
+
+class ProviderManager extends Manager
+{
+    const PROVIDER_METHOD = 'getWriteableProvider';
+    const FACADE_METHOD = 'getFacadeClass';
+
+    /**
+     * @param Package $package
+     * @param Framework $activeFramework
+     */
+    public function configure(Package $package, Framework $activeFramework)
+    {
+        if ($activeFramework->getName() !== 'Laravel') {
+            $this->cli->red("Configure {$package->getInstallSlug()} manual for {$activeFramework->getName()}, we currently only support Laravel");
+            return;
+        }
+        $configFile = $activeFramework->getPath('appConfig');
+        $newContent = $this->getNewConfig($configFile, $package);
+        $this->projectFilesystem->update($configFile, $newContent);
+    }
+
+    /**
+     * @param string $configFile
+     * @param Package $package
+     * @return array|bool
+     */
+    public function getNewConfig(string $configFile, Package $package)
+    {
+        $state = null;
+        $appConfig = file($configFile);
+
+        foreach($appConfig as $key => $line) {
+            $cleanLine = trim(preg_replace('/[\t\s]+/', '', $line));
+
+            switch ($cleanLine) {
+                case "'providers'=>[":
+                    $state = self::PROVIDER_METHOD;
+                    break;
+                case "'aliases'=>[":
+                    $state = self::FACADE_METHOD;
+                    break;
+            }
+
+            if ($cleanLine === "]," && $state !== null) {
+                $previousLine = --$key;
+                $appConfig[$previousLine] .= $this->$state($package);
+                $state = null;
+            }
+        }
+
+        return $appConfig;
+    }
+
+    /**
+     * @param Package $package
+     * @return string
+     */
+    public function getFacadeClass(Package $package)
+    {
+        [$alias, $facade] = explode('@', $package->getFacade());
+
+        return sprintf("\t\t'%s' => %s::class, ", $alias, $facade) . PHP_EOL;
+    }
+
+    /**
+     * @param Package $package
+     * @return string
+     */
+    public function getProviderClass(Package $package)
+    {
+
+        return sprintf("\t\t%s::class,", $package->getProvider()) . PHP_EOL;
+    }
+}

--- a/src/Skeletor/Manager/ProviderManager.php
+++ b/src/Skeletor/Manager/ProviderManager.php
@@ -65,7 +65,7 @@ class ProviderManager extends Manager
             return;
         }
 
-        $provider = explode('@', $package->getFacade());
+        $provider = explode('@', $facade);
 
         return sprintf("\t\t'%s' => %s::class,", $provider[0], $provider[1]) . PHP_EOL;
     }

--- a/src/Skeletor/Manager/ProviderManager.php
+++ b/src/Skeletor/Manager/ProviderManager.php
@@ -63,6 +63,11 @@ class ProviderManager extends Manager
      */
     public function getFacadeClass(Package $package)
     {
+        $facade = $package->getFacade();
+        if (isset($facade) === false) {
+            return;
+        }
+
         [$alias, $facade] = explode('@', $package->getFacade());
 
         return sprintf("\t\t'%s' => %s::class,", $alias, $facade) . PHP_EOL;
@@ -74,7 +79,11 @@ class ProviderManager extends Manager
      */
     public function getProviderClass(Package $package)
     {
+        $provider = $package->getProvider();
+        if (isset($provider) === false) {
+            return;
+        }
 
-        return sprintf("\t\t%s::class,", $package->getProvider()) . PHP_EOL;
+        return sprintf("\t\t%s::class,", $provider) . PHP_EOL;
     }
 }

--- a/src/Skeletor/Packages/BarryvdhLaravelDebugbarPackage.php
+++ b/src/Skeletor/Packages/BarryvdhLaravelDebugbarPackage.php
@@ -1,0 +1,18 @@
+<?php
+namespace Skeletor\Packages;
+
+use Skeletor\Frameworks\Framework;
+
+class BarryvdhLaravelDebugbarPackage extends Package implements ConfigurablePackageInterface
+{
+    public function setup()
+    {
+        $this->setInstallSlug("barryvdh/laravel-debugbar");
+        $this->setName("Barryvdh Laravel Debugbar");
+    }
+
+    public function configure(Framework $activeFramework)
+    {
+
+    }
+}

--- a/src/Skeletor/Packages/BarryvdhLaravelDebugbarPackage.php
+++ b/src/Skeletor/Packages/BarryvdhLaravelDebugbarPackage.php
@@ -9,6 +9,8 @@ class BarryvdhLaravelDebugbarPackage extends Package implements ConfigurablePack
     {
         $this->setInstallSlug("barryvdh/laravel-debugbar");
         $this->setName("Barryvdh Laravel Debugbar");
+        $this->setProvider('Barryvdh\Debugbar\ServiceProvider');
+        $this->setFacade('Debugbar@Barryvdh\Debugbar\Facade');
     }
 
     public function configure(Framework $activeFramework)

--- a/src/Skeletor/Packages/Package.php
+++ b/src/Skeletor/Packages/Package.php
@@ -12,8 +12,10 @@ abstract class Package implements PackageInterface
     protected $packageOptions = "";
     protected $mountManager;
     protected $installSlug;
+    protected $provider;
     protected $version = "";
     protected $options;
+    protected $facade;
     protected $name;
 
     /**
@@ -65,6 +67,7 @@ abstract class Package implements PackageInterface
     }
 
     /**
+     * @param bool $allowEmpty
      * @return string
      */
     public function getVersion(bool $allowEmpty = true)
@@ -98,6 +101,38 @@ abstract class Package implements PackageInterface
     public function setPackageOptions(string $packageOptions)
     {
         $this->packageOptions = $packageOptions;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getProvider()
+    {
+        return $this->provider;
+    }
+
+    /**
+     * @param string $provider
+     */
+    public function setProvider(string $provider)
+    {
+        $this->provider = $provider;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getFacade()
+    {
+        return $this->facade;
+    }
+
+    /**
+     * @param string $facade
+     */
+    public function setFacade(string $facade)
+    {
+        $this->facade = $facade;
     }
 
     public function install()

--- a/src/Skeletor/Packages/PackageInterface.php
+++ b/src/Skeletor/Packages/PackageInterface.php
@@ -12,5 +12,9 @@ interface PackageInterface
     public function setVersion(string $version);
     public function getPackageOptions();
     public function setPackageOptions(string $packageOptions);
+    public function getProvider();
+    public function setProvider(string $provider);
+    public function getFacade();
+    public function setFacade(string $facade);
     public function install();
 }

--- a/tests/unit/Skeletor/App/AppTest.php
+++ b/tests/unit/Skeletor/App/AppTest.php
@@ -26,7 +26,8 @@ class AppTest extends \Codeception\Test\Unit
                 'getVersion' => '0.0.1',
                 'getFrameworks' => ['Laravel54Framework'],
                 'getPackages' => ['BehatBehatPackage'],
-                'getDefaultPackages' => ['PixelfusionGitHooksPackage']
+                'getDefaultPackages' => ['PixelfusionGitHooksPackage'],
+                'getManagers' => ['ComposerManager', 'FrameworkManager', 'PackageManager']
             ]
         );
         $this->app = new App($config, $container, $config->getName(), $config->getVersion());

--- a/tests/unit/Skeletor/App/Manager/ComposerManagerTest.php
+++ b/tests/unit/Skeletor/App/Manager/ComposerManagerTest.php
@@ -27,9 +27,14 @@ class ComposerManagerTest extends \Codeception\Test\Unit
             [
             ]
         );
+        $projectFilesystem = Stub::make(
+            Filesystem::class,
+            [
+            ]
+        );
         $options = [];
 
-        $this->composerManager = new ComposerManager($cli, $skeletorFilesystem, $options);
+        $this->composerManager = new ComposerManager($cli, $skeletorFilesystem, $projectFilesystem, $options);
     }
 
     protected function _after()

--- a/tests/unit/Skeletor/App/Manager/FrameworkManagerTest.php
+++ b/tests/unit/Skeletor/App/Manager/FrameworkManagerTest.php
@@ -29,6 +29,11 @@ class FrameworkManagerTest extends \Codeception\Test\Unit
             [
             ]
         );
+        $projectFilesystem = Stub::make(
+            Filesystem::class,
+            [
+            ]
+        );
         $framework = Stub::make(
             Laravel54Framework::class,
             [
@@ -38,7 +43,7 @@ class FrameworkManagerTest extends \Codeception\Test\Unit
         );
 
         $options = [];
-        $this->frameworkManager = new FrameworkManager($cli, $skeletorFilesystem, $options);
+        $this->frameworkManager = new FrameworkManager($cli, $skeletorFilesystem, $projectFilesystem, $options);
 
         //Load one framework
         $this->frameworkManager->setFrameworks([$framework]);

--- a/tests/unit/Skeletor/App/Manager/PackageManagerTest.php
+++ b/tests/unit/Skeletor/App/Manager/PackageManagerTest.php
@@ -30,6 +30,11 @@ class PackageManagerTest extends \Codeception\Test\Unit
                 'read' => '{"Behat Behat":["v3.3.0","v3.2.3","v3.2.2","v3.2.1","v3.2.0rc2","v3.2.0rc1","v3.2.0","v3.1.0rc2","v3.1.0rc1","v3.1.0"]}',
             ]
         );
+        $projectFilesystem = Stub::make(
+            Filesystem::class,
+            [
+            ]
+        );
         $defaultPackage = Stub::make(
             PixelfusionGitHooksPackage::class,
             [
@@ -39,7 +44,7 @@ class PackageManagerTest extends \Codeception\Test\Unit
         );
 
         $options = [];
-        $this->packageManager = new PackageManager($cli, $skeletorFilesystem, $options);
+        $this->packageManager = new PackageManager($cli, $skeletorFilesystem, $projectFilesystem, $options);
 
         //Load one framework
         $this->packageManager->setDefaultPackages([$defaultPackage]);

--- a/tests/unit/Skeletor/App/Manager/ProviderManagerTest.php
+++ b/tests/unit/Skeletor/App/Manager/ProviderManagerTest.php
@@ -1,0 +1,84 @@
+<?php
+namespace Skeletor\App\Manager;
+
+
+use Codeception\Util\Stub;
+use League\CLImate\CLImate;
+use League\Flysystem\Filesystem;
+use Skeletor\Frameworks\Laravel54Framework;
+use Skeletor\Manager\ProviderManager;
+use Skeletor\Packages\PixelfusionGitHooksPackage;
+
+class ProviderManagerTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+    protected $framework;
+    protected $package;
+    protected $providerManager;
+
+    protected function _before()
+    {
+        $cli = Stub::make(
+            CLImate::class,
+            [
+                'red' => ''
+            ]
+        );
+        $skeletorFilesystem = Stub::make(
+            Filesystem::class,
+            [
+            ]
+        );
+        $projectFilesystem = Stub::make(
+            Filesystem::class,
+            [
+            ]
+        );
+
+        $this->framework = Stub::make(
+            Laravel54Framework::class,
+            [
+                'getName' => 'Laravel',
+                'getVersion' => '5.4',
+                'getPath' => 'app/config.php'
+            ]
+        );
+
+        $this->package = Stub::make(
+            PixelfusionGitHooksPackage::class,
+            [
+                'getInstallSlug' => 'pixelfusion/git-hooks',
+                'getName' => 'PixelFusion Git Hooks',
+                'getFacade' => 'Pixelfusion@Pixelfusion\Support\Facades\Config',
+                'getProvider' => 'Pixelfusion\PathExample\SampleServiceProvider'
+            ]
+        );
+
+        $options = [];
+        $this->providerManager = new ProviderManager($cli, $skeletorFilesystem, $projectFilesystem, $options);
+    }
+
+    protected function _after()
+    {
+    }
+
+    // tests
+    public function testGetFacadeClass()
+    {
+        $assert = "\t\t'Pixelfusion' => Pixelfusion\Support\Facades\Config::class," . PHP_EOL;
+        $facadeClass = $this->providerManager->getFacadeClass($this->package);
+
+        $this->assertStringMatchesFormat($assert, $facadeClass);
+    }
+
+    public function testGetProviderClass()
+    {
+        $assert = "\t\tPixelfusion\PathExample\SampleServiceProvider::class," . PHP_EOL;
+        $facadeClass = $this->providerManager->getProviderClass($this->package);
+
+        $this->assertStringMatchesFormat($assert, $facadeClass);
+    }
+}


### PR DESCRIPTION
| Q | A |
|--|--|
| Status | READY |
| Migrations | NO |
| Ticket | |

## Description :open_book: 

- Added support for registering providers and facades.
- Added the `barryvdh/laravel-debugbar`, here you can see to registering for the providers/facades in action.
- Refactored the app a bit
- Added more documentation  

## Steps to test/reproduce :walking: 
1. Pull the branch
1. Run `php skeletor project:create test123` -> build a Laravel 5.4 project with the `barryvdh/laravel-debugbar` package
1. After the install, check `config/app.php` the package reference should be in here. 
1. Run `./vendor/bin/codecept run` all the test should pass.

## Todos :white_check_mark: 
- [x] Tests
- [x] Documentation

## Deployment notes
At the moment the registering of packages only works for `Laravel`. You get a notification, when try to setup the packages on `Lumen`.