### PR TITLE
Check if there are packages set, otherwise dont do anything

### DIFF
--- a/src/Skeletor/Console/CreateProjectCommand.php
+++ b/src/Skeletor/Console/CreateProjectCommand.php
@@ -95,7 +95,11 @@ class CreateProjectCommand extends SkeletorCommand
         $padding->label('Framework')->result($activeFramework->getName());
         $padding->label('Version')->result($activeFramework->getVersion());
         $this->cli->br()->yellow('Packages:');
-        $this->cli->table($this->packageManager->showPackagesTable($activePackages));
+        if (empty($activePackages)) {
+            $this->cli->white('No packages selected');
+        } else {
+            $this->cli->table($this->packageManager->showPackagesTable($activePackages));
+        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
|--|--|
| Status | READY |
| Migrations | NO |
| Ticket | [Issue-13](https://github.com/pixelfusion/skeletor/issues/13) |

## Description
Fix for bug when not selecting optional packages.

## Steps to test/reproduce
1. Pull branch
1. Run `php skeletor project:create helloworld`
1. Don't select any optional packages
1. The installer should finish with success